### PR TITLE
Browser(ify) friendliness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2014-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+/**
+ * Similar to invariant but only logs a warning if the condition is not met.
+ * This can be used to log issues in development environments in critical
+ * paths. Removing the logging code for production environments will keep the
+ * same logic and follow the same code paths.
+ */
+
+var warning = function() {};
+
+if (process.env.NODE_ENV !== 'production') {
+  warning = function(condition, format, args) {
+    var len = arguments.length;
+    args = new Array(len > 2 ? len - 2 : 0);
+    for (var key = 2; key < len; key++) {
+      args[key - 2] = arguments[key];
+    }
+    if (format === undefined) {
+      throw new Error(
+        '`warning(condition, format, ...args)` requires a warning ' +
+        'message argument'
+      );
+    }
+
+    if (format.length < 10 || (/^[s\W]*$/).test(format)) {
+      throw new Error(
+        'The warning format should be able to uniquely identify this ' +
+        'warning. Please, use a more descriptive format than: ' + format
+      );
+    }
+
+    if (!condition) {
+      var argIndex = 0;
+      var message = 'Warning: ' +
+        format.replace(/%s/g, function() {
+          return args[argIndex++];
+        });
+      if (typeof console !== 'undefined') {
+        console.error(message);
+      }
+      try {
+        // This error was thrown as a convenience so that you can use this stack
+        // to find the callsite that caused this warning to fire.
+        throw new Error(message);
+      } catch(x) {}
+    }
+  };
+}
+
+module.exports = warning;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "invariant"
   ],
   "author": "Berkeley Martinez <berkeley@r3dm.com> (http://r3dm.com)",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/r3dm/warning/issues"
   },

--- a/package.json
+++ b/package.json
@@ -3,8 +3,17 @@
   "version": "1.0.2",
   "description": "A mirror of Facebook's Warning",
   "main": "warning.js",
+  "browser": "browser.js",
+  "browserify": {
+    "transform": [
+      "envify"
+    ]
+  },
   "scripts": {
     "test": "echo 'you've been warned'"
+  },
+  "dependencies": {
+    "envify": "^3.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds a browserify friendly version of the module. It allows for the package to be used in browserify builds with `detectGlobals: false`, and for the unused parts to be minified away.

cc: @BerkeleyTrue 
