### PR TITLE
Use console.warn instead of error

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -46,7 +46,7 @@ if (process.env.NODE_ENV !== 'production') {
           return args[argIndex++];
         });
       if (typeof console !== 'undefined') {
-        console.error(message);
+        console.warn(message);
       }
       try {
         // This error was thrown as a convenience so that you can use this stack

--- a/warning.js
+++ b/warning.js
@@ -48,7 +48,7 @@ if (__DEV__) {
           return args[argIndex++];
         });
       if (typeof console !== 'undefined') {
-        console.error(message);
+        console.warn(message);
       }
       try {
         // This error was thrown as a convenience so that you can use this stack


### PR DESCRIPTION
Somewhere along the line React switched to using `warn` instead;

https://github.com/facebook/react/blob/v0.13.3/src/vendor/core/warning.js#L48

sorry for the two commits, I did this using the github editor...
