### PR TITLE
Add tests and switch to "loose-envify"

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browser": "browser.js",
   "browserify": {
     "transform": [
-      "envify"
+      "loose-envify"
     ]
   },
   "files": [
@@ -17,7 +17,7 @@
     "test": "NODE_ENV=production tap test/*.js && NODE_ENV=development tap test/*.js"
   },
   "dependencies": {
-    "envify": "^3.0.0"
+    "loose-envify": "^1.0.0"
   },
   "devDependencies": {
     "browserify": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,19 @@
       "envify"
     ]
   },
+  "files": [
+    "browser.js",
+    "warning.js"
+  ],
   "scripts": {
-    "test": "echo 'you've been warned'"
+    "test": "NODE_ENV=production tap test/*.js && NODE_ENV=development tap test/*.js"
   },
   "dependencies": {
     "envify": "^3.0.0"
+  },
+  "devDependencies": {
+    "browserify": "^11.0.1",
+    "tap": "^1.4.0"
   },
   "repository": {
     "type": "git",

--- a/test/package/development.js
+++ b/test/package/development.js
@@ -1,0 +1,33 @@
+module.exports = function(t) {
+  var warning = require('../../');
+
+  t.throws(function() {
+    warning(true);
+  }, /requires a warning/i);
+
+  t.throws(function() {
+    warning(false);
+  }, /requires a warning/i);
+
+  t.throws(function() {
+    warning(true, 'short');
+  }, /use a more descriptive format/i);
+
+  t.throws(function() {
+    warning(false, 'short');
+  }, /use a more descriptive format/i);
+
+  var error = console.error;
+
+  console.error = function(msg) {
+    t.match(msg, /warning: warning message/i);
+  };
+  warning(false, 'warning message');
+
+  console.error = function(msg) {
+    t.ok(true); // should not be called
+  };
+  warning(true, 'warning message');
+
+  console.error = error;
+};

--- a/test/package/production.js
+++ b/test/package/production.js
@@ -1,0 +1,34 @@
+module.exports = function(t) {
+  var warning = require('../../');
+
+  t.doesNotThrow(function() {
+    warning(true);
+  });
+
+  t.doesNotThrow(function() {
+    warning(false);
+  });
+
+  t.doesNotThrow(function() {
+    warning(true, 'short');
+  });
+
+  t.doesNotThrow(function() {
+    warning(false, 'short');
+  });
+
+  var error = console.error;
+
+  console.error = function(msg) {
+    t.ok(true); // should not be called
+  };
+  warning(false, 'warning message');
+  t.ok(true); // so the test plan count matches development
+
+  console.error = function(msg) {
+    t.ok(true); // should not be called
+  };
+  warning(true, 'warning message');
+
+  console.error = error;
+};

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var browserify = require('browserify');
+var test = require('tap').test;
+var vm = require('vm');
+
+var file = __dirname + '/package/' + process.env.NODE_ENV + '.js';
+
+test('node', function(t) {
+  t.plan(5);
+  require(file)(t);
+});
+
+test('browserify', function(t) {
+  t.plan(8);
+  var b = browserify({
+    entries: file,
+    standalone: 'package'
+  });
+  b.bundle(function(err, src) {
+    t.notOk(err);
+    t.notMatch(String(src), /\bprocess\.env\.NODE_ENV\b/);
+    t.notMatch(String(src), /__DEV__/);
+    var c = {console: {}};
+    vm.runInNewContext(src, c);
+    c.package(t);
+  });
+});


### PR DESCRIPTION
Hey @BerkeleyTrue, I added some tests and switched to loose-envify. loose-envify is faster lighter version of envify for use with small libraries like this. When you publish this, please don't bump the major version, it'll cause a lot of downstream dependencies to have to update – a bump in minor or patch version should be sufficient. Thanks in advanced!
