### PR TITLE
Change console.error to console.warn

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -46,7 +46,7 @@ if (process.env.NODE_ENV !== 'production') {
           return args[argIndex++];
         });
       if (typeof console !== 'undefined') {
-        console.error(message);
+        console.warn(message);
       }
       try {
         // This error was thrown as a convenience so that you can use this stack


### PR DESCRIPTION
I believe this is a typo in the browser.js file that uses `console.error` instead of `console.warn`.  Please merge if this was unintentional, thanks!