### PR TITLE
Migrate to esm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+warning.cjs.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,18 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.2.tgz",
+      "integrity": "sha512-bjk1RIeZBCe/WukrFToIVegOf91Pebr8cXYBwLBIsfiGWVQ+ifwWsT59H3RxrWzWrzd1l/Amk1/ioY5Fq3/bpA==",
+      "dev": true
+    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -2217,6 +2229,16 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "rollup": {
+      "version": "0.59.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.59.2.tgz",
+      "integrity": "sha512-lu+yLa4xXMccYCKCQLIcGp4Rw2ZefFvJJUjuGQuFhZpCtggwe4SI0RYq2mV9/YDwYFXBYB7z3HrSxq1tSnzjkw==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "*"
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -2,23 +2,29 @@
   "name": "warning",
   "version": "4.0.0",
   "description": "A mirror of Facebook's Warning",
-  "main": "warning.js",
+  "main": "warning.cjs.js",
+  "module": "warning.js",
   "browserify": {
     "transform": [
       "loose-envify"
     ]
   },
   "files": [
-    "warning.js"
+    "warning.js",
+    "warning.cjs.js"
   ],
   "scripts": {
-    "test": "NODE_ENV=production tap test/*.js && NODE_ENV=development tap test/*.js"
+    "build": "rollup --input warning.js --file warning.cjs.js --format cjs",
+    "pretest": "npm run build",
+    "test": "NODE_ENV=production tap test/*.js && NODE_ENV=development tap test/*.js",
+    "prepublish": "npm run build"
   },
   "dependencies": {
     "loose-envify": "^1.0.0"
   },
   "devDependencies": {
     "browserify": "^11.0.1",
+    "rollup": "^0.59.2",
     "tap": "^1.4.0",
     "uglify-js": "^3.3.25"
   },

--- a/warning.js
+++ b/warning.js
@@ -61,4 +61,4 @@ if (__DEV__) {
   };
 }
 
-module.exports = warning;
+export default warning;


### PR DESCRIPTION
In this diff I convert source to esm so we can easily use this lib with
native browser modules. This also allow bundlers do not add additional
runtime to work around cjs.

I converted warning.js to esm and built warning.cjs.js with rollup.