### PR TITLE
fix: remove @providesModule annotation

### DIFF
--- a/warning.js
+++ b/warning.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @providesModule warning
  */
 
 'use strict';


### PR DESCRIPTION
this is a proprietary facebookism that causing annoying, impossible-to-fix errors in Flow if more than one version of `warning` winds up on our `node_modules`.

`invariant` has already done this: https://github.com/zertosh/invariant/commit/554a1797dd522585866a6603bca8e720c334f27f#diff-c1aaf5b663f5bfb219c0e8b32ee5c66e