### PR TITLE
Fix incorrect formatting of message with arguments

### DIFF
--- a/test/package/development.js
+++ b/test/package/development.js
@@ -21,8 +21,15 @@ module.exports = function() {
   warning(true, 'warning message');
 
   expect(mockFn).toHaveBeenCalledTimes(1);
-  expect(calls[0][0])
-    .toEqual(expect.stringMatching(/warning: warning message/i));
+  expect(mockFn).toHaveBeenCalledWith('Warning: warning message');
+
+  // should format message with arguments
+  warning(false, 'warning %s with one argument', 'message');
+  warning(false, 'warning %s with %s arguments', 'message', 'two');
+
+  expect(mockFn).toHaveBeenCalledTimes(3);
+  expect(mockFn).toHaveBeenCalledWith('Warning: warning message with one argument');
+  expect(mockFn).toHaveBeenCalledWith('Warning: warning message with two arguments');
 
   console.error = error;
 };

--- a/warning.js
+++ b/warning.js
@@ -21,9 +21,9 @@ var warning = function() {};
 if (__DEV__) {
   var printWarning = function printWarning(format, args) {
     var len = arguments.length;
-    args = new Array(len > 2 ? len - 2 : 0);
-    for (var key = 2; key < len; key++) {
-      args[key - 2] = arguments[key];
+    args = new Array(len > 1 ? len - 1 : 0);
+    for (var key = 1; key < len; key++) {
+      args[key - 1] = arguments[key];
     }
     var argIndex = 0;
     var message = 'Warning: ' +


### PR DESCRIPTION
Expected `warning(false, "Hello, %s!", "World")` to equal `"Hello, World!"` but got `"Hello, undefined!` instead.